### PR TITLE
Fix: Null event title: event title can be take into the topic

### DIFF
--- a/javascripts/discourse/widgets/layouts-event-list.js
+++ b/javascripts/discourse/widgets/layouts-event-list.js
@@ -76,7 +76,8 @@ createWidget("layouts-event-link", {
   buildKey: (attrs) => `layouts-event-link-${attrs.id}`,
 
   getEventTitle(event) {
-    const decodedEventName = htmlDecode(event.name); // needed for html entities in array
+    const eventName = event.name || event.post?.topic?.title;
+    const decodedEventName = htmlDecode(eventName); // needed for html entities in array
 
     const html = h("h3.l-event-item-title", decodedEventName);
     return html;


### PR DESCRIPTION
Fix Null in title of event : 
![image](https://user-images.githubusercontent.com/5228655/147416264-bddbce35-042a-4e3f-97c3-20c637c95eb1.png)
