### PR TITLE
Add 'after' param to /discourse-post-event/events.json call and Only show events of current category

### DIFF
--- a/javascripts/discourse/initializers/layouts-event-list.js.es6
+++ b/javascripts/discourse/initializers/layouts-event-list.js.es6
@@ -20,7 +20,10 @@ export default {
 
     if (layoutsError || !siteSettings.calendar_enabled) return;
 
-    ajax(`/discourse-post-event/events.json`).then((eventList) => {
+    const now = new Date();
+    ajax(
+      `/discourse-post-event/events.json?after=${now.toISOString()}`
+    ).then((eventList) => {
       const events = eventList.events;
       const props = {
         events,

--- a/javascripts/discourse/initializers/layouts-event-list.js.es6
+++ b/javascripts/discourse/initializers/layouts-event-list.js.es6
@@ -1,4 +1,3 @@
-import { ajax } from "discourse/lib/ajax";
 
 export default {
   name: "layouts-event-list",
@@ -20,15 +19,6 @@ export default {
 
     if (layoutsError || !siteSettings.calendar_enabled) return;
 
-    const now = new Date();
-    ajax(
-      `/discourse-post-event/events.json?after=${now.toISOString()}`
-    ).then((eventList) => {
-      const events = eventList.events;
-      const props = {
-        events,
-      };
-      layouts.addSidebarProps(props);
-    });
+    layouts.addSidebarProps({});
   },
 };


### PR DESCRIPTION
Add a 'after=' http param to ajax call.
And 'category_id' from the current browsed category.

Use with the review : 
https://github.com/discourse/discourse-calendar/pull/199
This commit add 'after' and 'before' param to events.json call :
https://github.com/discourse/discourse-calendar/pull/199/commits/f92146cf6f451b4993f3a674cd5af8d699184db9